### PR TITLE
Fix README integration status and remove redundant content

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,28 +138,24 @@ GenOps integrates natively with your AI and infrastructure layer to collect and 
 
 GenOps exports standardized telemetry and governance events to your existing stack.
 
-### Observability & Monitoring
-
-GenOps exports standardized telemetry and governance events to your existing stack.
-
-### Observability & Monitoring
+#### Observability & Monitoring
 
 ✅ [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)  
 ✅ [Datadog](https://www.datadoghq.com/)  
 ✅ [Grafana](https://grafana.com/) / [Loki](https://grafana.com/oss/loki/)  
 ✅ [Honeycomb](https://www.honeycomb.io/)  
-✅ [Prometheus](https://prometheus.io/) / [SigNoz](https://signoz.io/)  
-✅ [New Relic](https://newrelic.com/)  
-✅ [Jaeger](https://www.jaegertracing.io/)  
-✅ [Tempo](https://grafana.com/oss/tempo/)  
+✅ [Prometheus](https://prometheus.io/) / [Tempo](https://grafana.com/oss/tempo/)  
+☐ [New Relic](https://newrelic.com/)  
+☐ [Jaeger](https://www.jaegertracing.io/)  
+☐ [SigNoz](https://signoz.io/)  
 
-### Cost & FinOps Platforms
+#### Cost & FinOps Platforms
 
-✅ [OpenCost](https://www.opencost.io/)  
+☐ [OpenCost](https://www.opencost.io/)  
 ☐ [Finout](https://www.finout.io/) / [CloudZero](https://www.cloudzero.com/)  
 ☐ [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/) / [GCP Billing](https://cloud.google.com/billing/docs) / [Azure Cost Management](https://azure.microsoft.com/en-us/products/cost-management/)  
 ☐ [Cloudflare Workers AI Analytics](https://developers.cloudflare.com/workers-ai/)  
-✅ [Traceloop](https://traceloop.com/) / [OpenLLMetry](https://github.com/traceloop/openllmetry)  
+☐ [Traceloop](https://traceloop.com/) / [OpenLLMetry](https://github.com/traceloop/openllmetry)  
 
 ### Policy & Compliance
 


### PR DESCRIPTION
## Summary
- Remove duplicate "Observability & Monitoring" headers and redundant description text
- Correct integration status markers (✅/☐) based on actual repository documentation and examples
- Reorganize destinations section with proper hierarchy structure

## Issues Fixed

### 1. **Structural Redundancy**
- ❌ Removed duplicate "Observability & Monitoring" headers 
- ❌ Removed redundant description text that appeared 3 times
- ✅ Clean, single description with proper `####` subheadings

### 2. **Incorrect Integration Status** 
**✅ Verified as Actually Supported** (based on repository documentation/examples):
- **OpenTelemetry Collector** - Full configuration in `observability/otel-collector-config.yaml`
- **Datadog** - Dedicated example in `examples/observability/datadog_integration.py`
- **Grafana/Loki** - Complete setup in `observability/` directory with configs
- **Honeycomb** - Dedicated example in `examples/observability/honeycomb_integration.py`
- **Prometheus/Tempo** - Configuration files exist in observability stack

**☐ Changed to Unsupported** (no specific implementation found):
- **New Relic** - No dedicated integration examples
- **Jaeger** - No specific configuration or examples  
- **SigNoz** - No dedicated integration
- **OpenCost** - No specific implementation found
- **Traceloop/OpenLLMetry** - No dedicated integration examples

## Changes Made
- **Structure**: Clean destinations section with proper `####` hierarchy
- **Accuracy**: Status markers now reflect actual repository capabilities  
- **Organization**: Better grouping (e.g., combined Prometheus/Tempo into single line)
- **Readability**: Eliminated confusing duplications and redundant text

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Ensure all links remain functional  
- [x] Validate corrected integration status reflects actual repository state
- [x] Check that restructured content maintains all key information

🤖 Generated with [Claude Code](https://claude.ai/code)