### PR TITLE
docs(spec): clarify GenOps–OTel GenAI interoperability boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ GenOps does not modify or replace existing OpenTelemetry semantics.
 
 GenOps defines governance semantics. OpenTelemetry defines observability transport and structure. They are complementary.
 
+The [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) describe execution-level details such as model calls and token usage. GenOps defines the governance layer—policy decisions, accounting, and enforcement—and is designed to coexist with GenAI signals without overlap. Implementations MAY correlate GenOps telemetry with GenAI identifiers for a unified observability view.
+
 ---
 
 ## Compliance
@@ -101,6 +103,7 @@ GenOps does not define:
 - UI requirements
 - Model routing strategies
 - Authentication or authorization
+- Tracing topology, session/conversation identity, instrumentation APIs, or provider-specific telemetry schemas
 
 These concerns may be built on top of GenOps, but are outside the scope of the specification.
 

--- a/spec/genops-spec-v0.1.md
+++ b/spec/genops-spec-v0.1.md
@@ -67,11 +67,19 @@ This specification defines:
 
 ### 1.3 Relationship to OpenTelemetry
 
-GenOps extends OpenTelemetry. It defines additional semantic conventions in the `genops.*` attribute namespace. All GenOps telemetry MUST be representable using standard OpenTelemetry signals (traces, metrics, logs). GenOps does not modify, replace, or conflict with existing OpenTelemetry semantic conventions.
+GenOps extends OpenTelemetry. It defines additional semantic conventions in the `genops.*` attribute namespace. All GenOps telemetry MUST be representable using standard OpenTelemetry signals (traces, metrics, logs). GenOps does not modify, replace, or conflict with existing OpenTelemetry semantic conventions. In particular, the [OpenTelemetry Semantic Conventions for Generative AI](https://opentelemetry.io/docs/specs/semconv/gen-ai/) define descriptive attributes for model invocations, token usage, and tool calls. GenOps occupies a complementary domain: it defines the governance contract—policy decisions, accounting invariants, and enforcement outcomes—rather than descriptive execution telemetry. Implementations that emit both GenOps and GenAI signals produce a richer observability picture without overlap or conflict.
 
 ### 1.4 Versioning
 
 This is version 0.1.0 of the GenOps Governance Specification. The specification follows [Semantic Versioning 2.0.0](https://semver.org/). For version 1.0.0 and later, backwards-incompatible changes increment the major version. New attributes, events, or reason codes that do not remove or change existing definitions increment the minor version. For pre-1.0 stability rules, see Section 11.1. See Section 11 for the full versioning and compatibility policy.
+
+### 1.5 Interoperability with OpenTelemetry GenAI
+
+GenOps is designed to coexist with OpenTelemetry GenAI semantic conventions without requiring them:
+
+- **Correlation, not ownership.** When upstream identifiers such as `trace_id`, `span_id`, or optional session, conversation, and workflow identifiers are present, GenOps implementations MAY propagate them as correlation context. These identifiers are not GenOps normative identity; AWU identity is defined in Section 2.2.
+- **Topology agnostic.** GenOps does not prescribe instrumentation topology. It applies equally whether instrumentation is at the client, framework, server, or runtime layer.
+- **External signals as inputs.** Descriptive signals—retrieval context, memory state, tool invocations, guardrail findings, token-level usage telemetry—MAY inform governance decisions (e.g., a guardrail finding contributing to a BLOCKED enforcement outcome). GenOps does not standardize the schemas of those descriptive signals; it standardizes the governance outcome.
 
 ---
 
@@ -553,6 +561,10 @@ The following are explicitly out of scope for this specification:
 - **Agent orchestration.** Multi-agent graph topology, coordination protocols, and agent lifecycle management are not defined.
 - **Data retention or storage format.** The specification defines wire-level semantics, not storage.
 - **Specific SLA tier definitions.** Tiers are organization-defined. The specification defines the attribute schema only.
+- **Tracing topology semantics.** Distributed tracing structure (parent/child spans, trace propagation) is not defined by GenOps.
+- **Session, conversation, or workflow identity.** GenOps does not define these scoping constructs. GenOps MAY correlate with them when present but does not own or standardize them.
+- **Instrumentation APIs.** GenOps defines a semantic contract, not an instrumentation SDK or API surface.
+- **Provider-specific token or guardrail telemetry schemas.** GenOps does not define descriptive telemetry for token counts, guardrail evaluations, or similar signals. These schemas are the concern of observability conventions and provider SDKs.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds **Section 1.5 (Interoperability with OpenTelemetry GenAI)** establishing that GenOps coexists with OTel GenAI conventions without requiring them.
- Extends **Section 1.3** with complementary-domain framing (governance contract vs. descriptive execution telemetry).
- Adds four non-goals to **Section 10**: tracing topology, session/conversation/workflow identity, instrumentation APIs, provider-specific telemetry schemas — all framed as "GenOps does not define …".
- Mirrors boundary language in **README.md** (Relationship to OpenTelemetry + What GenOps Does Not Define).

**No compliance-surface change.** No new required attributes, events, decision states, reason codes, or conformance criteria are introduced. All interoperability wording uses MAY where applicable.

## Test plan

- [x] README format validator passes (`scripts/validate-readme-format.py`)
- [ ] Verify Section 1.5 renders correctly and TOC/numbering is intact
- [ ] Verify no contradiction between Section 1.3/1.5 and Section 2.2 AWU identity
- [ ] Verify Section 10 non-goals don't conflict with Section 7 telemetry conventions
- [ ] Verify README mirrors the same boundary language as spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)